### PR TITLE
#170919892 admin delete announcement

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-repo_token: 8TpkivP4HT5tsCHjVsBHKwMwenfc5w57R
+repo_token: ddfb2jieCs1ECJA841mWOt72R5pnHwMl9

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start:watch": "nodemon --exec babel-node src/app.js",
     "start": "babel-node src/app.js",
     "precover": "nyc --reporter=html --reporter=text npm run test",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "postcover": "npm run precover && npm run coverage"
   },
   "repository": {
     "type": "git",

--- a/src/controllers/announcement.js
+++ b/src/controllers/announcement.js
@@ -44,4 +44,15 @@ export default class AnouncementController {
           });
       }).catch(next);
   }
+
+  static delete(req, res, next) {
+    AnnouncementModel.delete(req.currentUser, +req.params.id)
+      .then((message) => {
+        res.status(200)
+          .json({
+            status: 'success',
+            message,
+          });
+      }).catch(next);
+  }
 }

--- a/src/models/announcement.js
+++ b/src/models/announcement.js
@@ -78,7 +78,7 @@ export default class AnouncementController {
           .then((queryRes) => {
             const results = queryRes.rows[0].f_create_announcement;
             if (results.status === 'success') {
-              resolve(results);
+              resolve(results.data);
             } else {
               const newError = new Error(results.message);
               newError.status = 401;
@@ -99,6 +99,27 @@ export default class AnouncementController {
       Db.query(query)
         .then((queryRes) => {
           const results = queryRes.rows[0].f_update_announcement;
+          if (results.status === 'success') {
+            resolve(results.message);
+          } else {
+            const newError = new Error(results.message);
+            newError.status = Number(results.status);
+            reject(newError);
+          }
+        })
+        .catch(reject);
+    });
+  }
+
+  static delete(currentUser, announcementId) {
+    return new Promise((resolve, reject) => {
+      const query = {
+        text: 'select f_delete_announcement($1,$2);',
+        params: [currentUser, announcementId],
+      };
+      Db.query(query)
+        .then((queryRes) => {
+          const results = queryRes.rows[0].f_delete_announcement;
           if (results.status === 'success') {
             resolve(results.message);
           } else {

--- a/src/routes/announcements.js
+++ b/src/routes/announcements.js
@@ -9,5 +9,6 @@ router.get('/', [Auth.getCurrentUser], AnouncementController.getAll);
 router.get('/:id', [Auth.getCurrentUser], AnouncementController.getOne);
 router.post('/', [Auth.getCurrentUser], AnouncementController.create);
 router.patch('/:id', [Auth.getCurrentUser], AnouncementController.update);
+router.delete('/:id', [Auth.getCurrentUser], AnouncementController.delete);
 
 export default router;


### PR DESCRIPTION
#### Description
Create an endpoint to receive a DELETE requests to delete a specific announcement
#### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update
#### How Has This Been Tested?
- [x] Unit
- [ ] Integration
- [ ] End-to-end
#### How to Test
After cloning the repo, run `npm i`, then `npm run start` to start the server on port 3000
Authenticate as admin and send a DELETE request to the app at /api/v1/announcement:/[:id] [:id] being the announcement id you want to delete.
#### Any background context you want to add
none
#### Pivotal Tracker
[Finishes #170919892 ]
