### PR TITLE
#170989581 admin view all advertisers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AnnounceIT REST API
 
-[![Coverage Status](https://coveralls.io/repos/github/karamuka/announceit-rest-api/badge.svg?branch=ft-admin-delete-announcement-170919892)](https://coveralls.io/github/karamuka/announceit-rest-api?branch=ft-admin-delete-announcement-170919892)
+[![Coverage Status](https://coveralls.io/repos/github/karamuka/announceit-rest-api/badge.svg?branch=admin-view-advertisers-170989581)](https://coveralls.io/github/karamuka/announceit-rest-api?branch=admin-view-advertisers-170989581)
 
 [![Build Status](https://travis-ci.org/karamuka/announceit-rest-api.svg?branch=ft-admin-view-all-announcements-170920345)](https://travis-ci.org/karamuka/announceit-rest-api)

--- a/src/app.js
+++ b/src/app.js
@@ -1,12 +1,11 @@
 import express from 'express';
 import dotenv from 'dotenv';
-import { Auth, Announcements } from './routes';
+import { Auth, Announcements, User } from './routes';
 
 dotenv.config();
 
 const app = express();
-const HOST = process.env.HOST || '0.0.0.0';
-const PORT = process.env.PORT || 3000;
+const { HOST, PORT } = process.env;
 
 // Handle CORS
 app.use((req, res, next) => {
@@ -27,6 +26,7 @@ app.use(express.json());
 
 app.use('/api/v1/auth', Auth);
 app.use('/api/v1/announcement', Announcements);
+app.use('/api/v1/user', User);
 
 // handle 404
 app.use((req, res, next) => {

--- a/src/app.spec.js
+++ b/src/app.spec.js
@@ -116,6 +116,27 @@ describe('User', () => {
     }).timeout(15000);
   });
 
+  describe('Advertisers', () => {
+    it('admin should view all users', (done) => {
+      request(app)
+        .get('/api/v1/user')
+        .set('Authorization', TEST_TOKEN)
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          return done();
+        });
+    }).timeout(15000);
+    it('advertiser should not view all users', (done) => {
+      request(app)
+        .get('/api/v1/user')
+        .set('Authorization', createdData.user.token)
+        .end((err, res) => {
+          expect(res.status).to.equal(401);
+          return done();
+        });
+    }).timeout(15000);
+  });
+
   describe('Announcements', () => {
     it('advertiser should create a new announcement', (done) => {
       request(app)

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -1,32 +1,20 @@
 import { UserModel } from '../models';
 
 export default class AuthController {
-  static signUp(req, res) {
+  static signUp(req, res, next) {
     UserModel.signUp(req.body)
       .then((newUser) => {
         res.status(201).json(newUser);
       })
-      .catch((err) => {
-        res.status(err.status || 500)
-          .json({
-            status: 'error',
-            error: err.message || err,
-          });
-      });
+      .catch(next);
   }
 
-  static signIn(req, res) {
+  static signIn(req, res, next) {
     UserModel.signIn(req.body)
       .then((authUser) => {
         res.status(201)
           .json(authUser);
       })
-      .catch((err) => {
-        res.status(err.status || 500)
-          .json({
-            status: 'error',
-            error: err.message,
-          });
-      });
+      .catch(next);
   }
 }

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,7 +1,9 @@
 import AnouncementController from './announcement';
 import AuthController from './auth';
+import UserController from './user';
 
 export {
   AuthController,
   AnouncementController,
+  UserController,
 };

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -1,0 +1,14 @@
+import { UserModel } from '../models';
+
+export default class AnouncementController {
+  static getAll(req, res, next) {
+    UserModel.getAll(req.currentUser)
+      .then((users) => {
+        res.status(200)
+          .json({
+            status: 'success',
+            data: users,
+          });
+      }).catch(next);
+  }
+}

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -109,4 +109,25 @@ export default class User {
         .catch(reject);
     });
   }
+
+  static getAll(currentUser) {
+    return new Promise((resolve, reject) => {
+      const query = {
+        text: 'select f_get_users($1);',
+        params: [currentUser],
+      };
+      Db.query(query)
+        .then((queryRes) => {
+          const results = queryRes.rows[0].f_get_users;
+          if (results.status === 'success') {
+            resolve(results.data);
+          } else {
+            const newError = new Error(results.message);
+            newError.status = +results.status;
+            reject(newError);
+          }
+        })
+        .catch(reject);
+    });
+  }
 }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,7 +1,9 @@
 import Auth from './auth';
 import Announcements from './announcements';
+import User from './user';
 
 export {
   Auth,
   Announcements,
+  User,
 };

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+import { UserController } from '../controllers';
+import Auth from '../middlewares/auth';
+
+const router = Router();
+
+router.get('/', [Auth.getCurrentUser], UserController.getAll);
+
+export default router;

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -13,19 +13,15 @@ export default class Database {
   static query({ text, params }) {
     return new Promise((resolve, reject) => {
       const client = new Client({ connectionString: connStr });
-      client.connect((err) => {
-        if (err) {
-          reject(err);
-        } else {
-          client.query(text, params, (queryErr, queryRes) => {
-            if (queryErr) {
-              reject(queryErr);
-            } else {
-              client.end();
-              resolve(queryRes);
-            }
-          });
-        }
+      client.connect(() => {
+        client.query(text, params, (queryErr, queryRes) => {
+          if (queryErr) {
+            reject(queryErr);
+          } else {
+            client.end();
+            resolve(queryRes);
+          }
+        });
       });
     });
   }


### PR DESCRIPTION
#### Description
Create an endpoint to receive a GET requests to retrieve all advertisers 
#### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update
#### How Has This Been Tested?
- [x] Unit
- [ ] Integration
- [ ] End-to-end
#### How to Test
After cloning the repo, run `npm i`, then `npm run start` to start the server on port 3000
Authenticate as admin and send a GET request to the app at /api/v1/user.
#### Any background context you want to add
none
#### Pivotal Tracker
[Finishes #170989581]
