### PR TITLE
#170990038 admin delete advertiser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AnnounceIT REST API
 
-[![Coverage Status](https://coveralls.io/repos/github/karamuka/announceit-rest-api/badge.svg?branch=admin-view-advertisers-170989581)](https://coveralls.io/github/karamuka/announceit-rest-api?branch=admin-view-advertisers-170989581)
+[![Coverage Status](https://coveralls.io/repos/github/karamuka/announceit-rest-api/badge.svg?branch=ft-admin-delete-advertiser-170990038)](https://coveralls.io/github/karamuka/announceit-rest-api?branch=ft-admin-delete-advertiser-170990038)
 [![Build Status](https://travis-ci.org/karamuka/announceit-rest-api.svg?branch=ft-admin-view-all-announcements-170920345)](https://travis-ci.org/karamuka/announceit-rest-api)
 
 ## overview

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # AnnounceIT REST API
 
 [![Coverage Status](https://coveralls.io/repos/github/karamuka/announceit-rest-api/badge.svg?branch=admin-view-advertisers-170989581)](https://coveralls.io/github/karamuka/announceit-rest-api?branch=admin-view-advertisers-170989581)
-
 [![Build Status](https://travis-ci.org/karamuka/announceit-rest-api.svg?branch=ft-admin-view-all-announcements-170920345)](https://travis-ci.org/karamuka/announceit-rest-api)
+
+## overview
+
+Since the rise of the internet, more people have switched their attention from spending hours
+watching TV and listening to the radio or even reading newspapers to scrolling and tapping on
+their phones and laptops. Businesses can now reach more eyeballs online than the more
+traditional approaches.
+
+AnnounceIT comes in as a solution to broadcasting agencies which will will allow them to be able
+to receive and manage announcements.

--- a/src/app.spec.js
+++ b/src/app.spec.js
@@ -126,7 +126,7 @@ describe('User', () => {
           return done();
         });
     }).timeout(15000);
-    it('advertiser should not view all users', (done) => {
+    it('should not view all users', (done) => {
       request(app)
         .get('/api/v1/user')
         .set('Authorization', createdData.user.token)
@@ -138,7 +138,7 @@ describe('User', () => {
   });
 
   describe('Announcements', () => {
-    it('advertiser should create a new announcement', (done) => {
+    it('should create a new announcement', (done) => {
       request(app)
         .post('/api/v1/announcement')
         .send(createdData.announcement)
@@ -149,7 +149,7 @@ describe('User', () => {
           return done();
         });
     }).timeout(15000);
-    it('advertiser should not create an announcement with invalid input', (done) => {
+    it('should not create an announcement with invalid input', (done) => {
       request(app)
         .post('/api/v1/announcement')
         .send({ title: '' })
@@ -159,7 +159,7 @@ describe('User', () => {
           return done();
         });
     }).timeout(15000);
-    it('advertiser should update a specific announcement', (done) => {
+    it('should update a specific announcement', (done) => {
       request(app)
         .patch(`/api/v1/announcement/${+createdData.announcement.id}`)
         .set('Authorization', createdData.user.token)
@@ -183,7 +183,7 @@ describe('User', () => {
           return done();
         });
     }).timeout(15000);
-    it('advertiser should not update announcement status', (done) => {
+    it('should not update announcement status', (done) => {
       request(app)
         .patch(`/api/v1/announcement/${+createdData.announcement.id}`)
         .set('Authorization', createdData.user.token)
@@ -207,7 +207,7 @@ describe('User', () => {
           return done();
         });
     }).timeout(15000);
-    it('advertiser should view all his/her announcements', (done) => {
+    it('should view all his/her announcements', (done) => {
       request(app)
         .get('/api/v1/announcement')
         .set('Authorization', createdData.user.token)
@@ -261,7 +261,7 @@ describe('User', () => {
           return done();
         });
     }).timeout(15000);
-    it('advertiser should not delete announcement', (done) => {
+    it('should not delete announcement', (done) => {
       request(app)
         .delete(`/api/v1/announcement/${+createdData.announcement.id}`)
         .set('Authorization', createdData.user.token)
@@ -273,6 +273,27 @@ describe('User', () => {
     it('admin should delete announcement', (done) => {
       request(app)
         .delete(`/api/v1/announcement/${+createdData.announcement.id}`)
+        .set('Authorization', TEST_TOKEN)
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          return done();
+        });
+    }).timeout(15000);
+  });
+
+  describe('Account management', () => {
+    it('should not delete an advertiser', (done) => {
+      request(app)
+        .delete(`/api/v1/user/${createdData.user.id}`)
+        .set('Authorization', createdData.user.token)
+        .end((err, res) => {
+          expect(res.status).to.equal(401);
+          return done();
+        });
+    }).timeout(15000);
+    it('should delete an advertiser', (done) => {
+      request(app)
+        .delete(`/api/v1/user/${createdData.user.id}`)
         .set('Authorization', TEST_TOKEN)
         .end((err, res) => {
           expect(res.status).to.equal(200);

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -11,4 +11,15 @@ export default class AnouncementController {
           });
       }).catch(next);
   }
+
+  static delete(req, res, next) {
+    UserModel.delete(req.currentUser, req.params.id)
+      .then((message) => {
+        res.status(200)
+          .json({
+            status: 'success',
+            message,
+          });
+      }).catch(next);
+  }
 }

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -130,4 +130,25 @@ export default class User {
         .catch(reject);
     });
   }
+
+  static delete(currentUser, userId) {
+    return new Promise((resolve, reject) => {
+      const query = {
+        text: 'select f_delete_user($1,$2);',
+        params: [currentUser, userId],
+      };
+      Db.query(query)
+        .then((queryRes) => {
+          const results = queryRes.rows[0].f_delete_user;
+          if (results.status === 'success') {
+            resolve(results.message);
+          } else {
+            const newError = new Error(results.message);
+            newError.status = +results.status;
+            reject(newError);
+          }
+        })
+        .catch(reject);
+    });
+  }
 }

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -6,5 +6,6 @@ import Auth from '../middlewares/auth';
 const router = Router();
 
 router.get('/', [Auth.getCurrentUser], UserController.getAll);
+router.delete('/:id', [Auth.getCurrentUser], UserController.delete);
 
 export default router;


### PR DESCRIPTION
#### Description
Create an endpoint to receive a DELETE requests to delete a specific advertiser
#### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update
#### How Has This Been Tested?
- [x] Unit
- [ ] Integration
- [ ] End-to-end
#### How to Test
After cloning the repo, run `npm i`, then `npm run start` to start the server on port 3000
Authenticate as admin and send a DELETE request to the app at /api/v1/user:/[:id] [:id] being the advertiser id you want to delete.
#### Any background context you want to add
none
#### Pivotal Tracker
[Finishes #170990038]
